### PR TITLE
Pydelphin versions

### DIFF
--- a/Formula/pydelphin.rb
+++ b/Formula/pydelphin.rb
@@ -3,8 +3,8 @@ class Pydelphin < Formula
 
   desc "Python libraries for DELPH-IN"
   homepage "https://github.com/delph-in/pydelphin"
-  url "https://github.com/delph-in/pydelphin/archive/v1.2.3.tar.gz"
-  sha256 "273b1429c91c7579fccc5fa7cfe9a5fe2185fb4cb65d73823ccf964e8db751de"
+  url "https://github.com/delph-in/pydelphin/archive/v1.5.1.tar.gz"
+  sha256 "0fda880ecbb2f321ab6227945503d2268623347b224ca3ab061762dea1b43f82"
 
   depends_on "delph-in/delphin/ace"
   depends_on "python"
@@ -17,11 +17,6 @@ class Pydelphin < Formula
   resource "progress" do
     url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
     sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
-  end
-
-  resource "PyDelphin" do
-    url "https://files.pythonhosted.org/packages/3f/cb/5dc539f06ffa3ca183cf435db69fad0b3ee1ed669b5447a73b988e7395c8/PyDelphin-1.2.3.tar.gz"
-    sha256 "3ffc4a4ffdc4a94a393d57153011934338f5d5f0eda4b780e959a5675bb48589"
   end
 
   def install

--- a/Formula/pydelphin@1.0.0.rb
+++ b/Formula/pydelphin@1.0.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT100 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.0.0.tar.gz"
+  sha256 "c7022d1c615773970dd3281cf683278225766b616fefada1b3df36bd5e9b7d7a"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.0.1.rb
+++ b/Formula/pydelphin@1.0.1.rb
@@ -1,0 +1,68 @@
+class PydelphinAT101 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.0.1.tar.gz"
+  sha256 "019cb4edce9b2681dd69897c926347e00f1768be929f5e9bebe0d897fc39cecb"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.0.2.rb
+++ b/Formula/pydelphin@1.0.2.rb
@@ -1,0 +1,68 @@
+class PydelphinAT102 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.0.2.tar.gz"
+  sha256 "9d8df4e3b6a54c21cfa55d83996e5856f9e36c5eb1fd137c7ed58d43d302b1c9"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.0.3.rb
+++ b/Formula/pydelphin@1.0.3.rb
@@ -1,0 +1,68 @@
+class PydelphinAT103 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.0.3.tar.gz"
+  sha256 "8f3f3e3c97c354646264fa91177e683129956cfe7d877f276c50c8ba096c5c2f"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.1.0.rb
+++ b/Formula/pydelphin@1.1.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT110 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.1.0.tar.gz"
+  sha256 "8e7b3061ab3d4743176f8d25e7da2a4c2b888933e5b316611611199a25e9fb67"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.2.0.rb
+++ b/Formula/pydelphin@1.2.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT120 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.2.0.tar.gz"
+  sha256 "1.2.05757504877062477b1e48556182c5156b7cdeb60004fe26be5e3d874194"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.2.1.rb
+++ b/Formula/pydelphin@1.2.1.rb
@@ -1,0 +1,68 @@
+class PydelphinAT121 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.2.1.tar.gz"
+  sha256 "d12a0952b427def0863aa3d1dfb34392bdf27fdd4ab5b0443dfb90aad77aa3c4"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.2.2.rb
+++ b/Formula/pydelphin@1.2.2.rb
@@ -1,0 +1,68 @@
+class PydelphinAT122 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.2.2.tar.gz"
+  sha256 "be522ebc666f9a43efb6411733671b889f2add4c8b6e5eda1caa4bb52c9577d2"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.2.3.rb
+++ b/Formula/pydelphin@1.2.3.rb
@@ -1,0 +1,68 @@
+class PydelphinAT123 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.2.3.tar.gz"
+  sha256 "273b1429c91c7579fccc5fa7cfe9a5fe2185fb4cb65d73823ccf964e8db751de"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.2.4.rb
+++ b/Formula/pydelphin@1.2.4.rb
@@ -1,0 +1,68 @@
+class PydelphinAT124 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.2.4.tar.gz"
+  sha256 "585aae1a88706a85d1d0515287d98f1ec4775b7999a69febed17224a3586c49a"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.3.0.rb
+++ b/Formula/pydelphin@1.3.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT130 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.3.0.tar.gz"
+  sha256 "c421a58f1bbc119b088089207f771d600b0c3e7f74a512488585374e74a7d7cd"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.4.0.rb
+++ b/Formula/pydelphin@1.4.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT140 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.4.0.tar.gz"
+  sha256 "0f6fb2628f2cb4c2bd23e55c0feb495f4eeb09589d98714428e50894e1bb4204"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.4.1.rb
+++ b/Formula/pydelphin@1.4.1.rb
@@ -1,0 +1,68 @@
+class PydelphinAT141 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.4.1.tar.gz"
+  sha256 "2c91ef1754eff7d32dd865d35a2317590991d33a1050e6c01fb62b9caaacfcd8"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end

--- a/Formula/pydelphin@1.5.0.rb
+++ b/Formula/pydelphin@1.5.0.rb
@@ -1,0 +1,68 @@
+class PydelphinAT150 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python libraries for DELPH-IN"
+  homepage "https://github.com/delph-in/pydelphin"
+  url "https://github.com/delph-in/pydelphin/archive/v1.5.0.tar.gz"
+  sha256 "cfb23d301a299f2773d53f5b8f8d374381f2b3e9269e4751fae9c77924f38e73"
+
+  depends_on "delph-in/delphin/ace"
+  depends_on "python"
+
+  resource "Penman" do
+    url "https://files.pythonhosted.org/packages/a2/3d/50a8b1c7d6632fa793b406485d9ed0afa8683442d0aa83462c0ab7b67560/Penman-0.9.1.tar.gz"
+    sha256 "ec1b0071948563d59004e11bd5c0e4696b4ceba95bf946367a4ba2b99bcd4f42"
+  end
+
+  resource "progress" do
+    url "https://files.pythonhosted.org/packages/38/ef/2e887b3d2b248916fc2121889ce68af8a16aaddbe82f9ae6533c24ff0d2b/progress-1.5.tar.gz"
+    sha256 "69ecedd1d1bbe71bf6313d88d1e6c4d2957b7f1d4f71312c211257f7dae64372"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink libexec/"bin/delphin"
+  end
+
+  test do
+    resource "tiniest-grammar" do
+      url "https://github.com/dantiston/delphin-tiniest-grammar/archive/v1.0.0.tar.gz"
+      sha256 "d24542f56fc5dbb63ba761f3bc292c5e01178e9dbefa024bc00ba9a04cbc210b"
+    end
+
+    testpath.install resource("tiniest-grammar")
+    # Write TSDB info
+    (testpath/"sentences.txt").write <<~EOS
+      i-wf@i-input@i-author
+      1@n1 iv@author
+      2@iv n1@author
+    EOS
+
+    (testpath/"relations.txt").write <<~EOS
+      item:
+        i-input :string
+        i-wf :integer
+        i-author :string
+
+      run:
+        run-id :integer :key
+
+      parse:
+        parse-id :integer :key
+        run-id :integer :key
+        i-id :integer :key
+    EOS
+
+    # Make the profile
+    system bin/"delphin", "mkprof", testpath/"tests", "--delimiter=\"@\"", "--relations", "relations.txt", "--input",
+"sentences.txt"
+    assert_predicate testpath/"tests"/"item", :exist?
+
+    # Compile the grammar & process profile
+    system Formula["delph-in/delphin/ace"].bin/"ace", "-g", "config.tdl", "-G", testpath/"grammar.dat"
+    system bin/"delphin", "process", "-g", testpath/"grammar.dat", testpath/"tests"
+
+    assert_predicate testpath/"tests"/"run", :exist?
+    assert_predicate testpath/"tests"/"parse", :exist?
+  end
+end


### PR DESCRIPTION
* Update pydelphin to latest 1.5.1
* Add historical versions for `('1.0.0' '1.0.1' '1.0.2' '1.0.3' '1.1.0' '1.2.0' '1.2.1' '1.2.2' '1.2.3' '1.2.4' '1.3.0' '1.4.0' '1.4.1' '1.5.0')`

Script to create versions:
```
versions=('1.0.0' '1.0.1' '1.0.2' '1.0.3' '1.1.0' '1.2.0' '1.2.1' '1.2.2' '1.2.3' '1.2.4' '1.3.0' '1.4.0' '1.4.1' '1.5.0')
for v in $versions[@]; do cp pydelphin.rb pydelphin@$v.rb; done;
for f in pydelphin@*rb; do version=$(echo ${f%.*}.${f##*.} | sed 's/pydelphin@//g' | sed 's/.rb//g' | sed 's/\.//g'); sed -i '' "s/Pydelphin < Formula/PydelphinAT${version} < Formula/g" $f; done;
for f in pydelphin@*rb; do version=$(echo ${f%.*}.${f##*.} | sed 's/pydelphin@//g' | sed 's/.rb//g'); sed -i '' "s/https://github.com/delph-in/pydelphin/archive/v1.5.1.tar.gz/https://github.com/delph-in/pydelphin/archive/v$version.tar.gz/g" $f; done;
for f in pydelphin@*rb; do version=$(echo ${f%.*}.${f##*.} | sed 's/pydelphin@//g' | sed 's/.rb//g'); hash=$(curl https://codeload.github.com/delph-in/pydelphin/tar.gz/v$version 2>/dev/null | sha256sum | sed 's/  -//g'); sed -i '' "s/sha256 \"0fda880ecbb2f321ab6227945503d2268623347b224ca3ab061762dea1b43f82\"/sha256 \"$hash\"/g" $f; done;
for f in pydelphin@*rb; do version=$(echo ${f%.*}.${f##*.} | sed 's/pydelphin@//g' | sed 's/.rb//g'); sed -i '' "s/1.5.1/$version/g" $f; done;
```